### PR TITLE
fix: try adjust modal overlay again

### DIFF
--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -17,7 +17,7 @@ const ImageModal = ({
     <div>
       {modalOpen &&
         <div
-          className='z-10 fixed top-0 left-0 size-full max-h-svh bg-white/98 dark:bg-black/98 flex flex-col justify-center items-center p-0 cursor-pointer'
+          className='z-10 fixed top-0 left-0 size-full bg-white/98 dark:bg-black/98 flex flex-col justify-center items-center p-0 cursor-pointer'
           role="dialog"
           aria-modal="true"
           tabIndex={0}
@@ -35,7 +35,7 @@ const ImageModal = ({
             </button>
           </div>
 
-          <div className='grow pb-4'>
+          <div className='flex-1 min-h-0 pb-4'>
             <Image
               src={imageUrl}
               width={500}


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove `max-h-svh` constraint from modal overlay

- Replace `grow` with `flex-1 min-h-0` for image container


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Modal Overlay"] --> B["Remove max-h-svh"]
  A --> C["Image Container"]
  C --> D["Replace grow with flex-1 min-h-0"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ImageModal.tsx</strong><dd><code>Fix modal overlay and container layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/ImageModal.tsx

<ul><li>Remove <code>max-h-svh</code> from modal overlay className<br> <li> Change image container from <code>grow</code> to <code>flex-1 min-h-0</code></ul>


</details>


  </td>
  <td><a href="https://github.com/olgapinheiro/bieco-garcia-portfolio/pull/18/files#diff-deefa87af45af4abc9b47887c187cd96b0bb64db104debd2e081aa5ad7d1d50a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

